### PR TITLE
[Feat] Implement Logic for Delete Comment API Request

### DIFF
--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -91,11 +91,12 @@ router.delete("/:commentId", async (req, res, next) => {
   try {
     const commentId = req.params.commentId;
     const comment = await Comment.findById(commentId);
-    const user = await User.findById(comment.creator);
 
     if (!comment) {
       return res.status(404).json({ message: "No such comment was found." });
     }
+
+    const user = await User.findById(comment.creator);
 
     if (!user) {
       return res.status(404).json({ message: "Creator not found" });

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -114,7 +114,7 @@ router.delete("/:commentId", async (req, res, next) => {
         (comment) => comment.toString() !== commentId,
       );
 
-      await user.save();
+      await writer.save();
     }
 
     await comment.findByIdAndDelete(commentId);

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -87,4 +87,42 @@ router.get("/:commentId", async (req, res, next) => {
   }
 });
 
+router.delete("/:commentId", async (req, res, next) => {
+  try {
+    const commentId = req.params.commentId;
+    const comment = await Comment.findById(commentId);
+    const user = await User.findById(comment.creator);
+
+    if (!comment) {
+      return res.status(404).json({ message: "No such comment was found." });
+    }
+
+    if (!user) {
+      return res.status(404).json({ message: "Creator not found" });
+    }
+
+    user.createdComments = user.createdComments.filter(
+      (comment) => comment.toString() !== commentId,
+    );
+
+    await user.save();
+
+    for (const reComment of comment.reComments) {
+      const writer = await User.findById(reComment.creator);
+
+      writer.participatedComments = writer.participatedComments.filter(
+        (comment) => comment.toString() !== commentId,
+      );
+
+      await user.save();
+    }
+
+    await comment.findByIdAndDelete(commentId);
+
+    res.status(200).json({ message: "comment was successfully deleted." });
+  } catch (error) {
+    return res.status(400).json({ message: "Failed to delete a comment." });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
# Comment 삭제하기
## Todo
- [x]  자신이 작성한 commetn의 경우 삭제버튼이 활성화 되어있고 클릭시 `/comment/commintId` DELETE요청
- [x]  commentId가 일치하는 댓글 삭제
- [x]  해당 사용자의 createdComments 요소 배열에서 해당 comment 삭제
- [x]  전체 사용자의 particpatedComments 요소 배열에서 해당 comment 존재시 삭제
- [x]  응답으로 결과 전달(실패시 결과와 에러메시지 전달)

## comments/commentId Delete 요청 구현.
- req.params로 전달받은 commentId와 일치하는 comment가 없을시 404에러 메시지 전달
- 해당 comment의 creator와 동일한 user._Id가 없을시 404에러 메시지 전달
- 해당 user의 createdComments 배열에서 해당 comment를 제외
- comment의 reComments를 돌면서 해당 reComments의 작성자 접근
- reComments작성자의 participatedComments 배열에서 해당 comment를 제외
- 해당 comment 삭제

## PR전 확인사항
- [x]  가장 최신 브랜치를 pull
- [x]  브랜치명 확인하기
- [x]  코드 컨벤션을 모두 지키기
- [x] PR제목이 브랜치명, task명을 포함하기
- [x] reviewer, assignee 확인하기
