### PR TITLE
[Feat] Implement /location endpoint for handling GET requests

### DIFF
--- a/src/loaders/express.js
+++ b/src/loaders/express.js
@@ -6,8 +6,8 @@ const cors = require("cors");
 
 async function expressLoader(app) {
   app.use(logger("dev"));
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json({ limit: "5mb" }));
+  app.use(express.urlencoded({ limit: "5mb", extended: false }));
   app.use(cookieParser());
   app.use(express.static(path.join(__dirname, "public")));
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -8,18 +8,14 @@ const userSchema = new mongoose.Schema({
   icon: { type: String },
   friends: [{ type: Schema.Types.ObjectId, ref: "User" }],
   createdComments: [{ type: Schema.Types.ObjectId, ref: "Comment" }],
+  receivedComments: [{ type: Schema.Types.ObjectId, ref: "Comment" }],
   repliedComments: [
     {
       comment: { type: Schema.Types.ObjectId, ref: "Comment" },
       text: { type: String },
     },
   ],
-  accessibleComments: [
-    {
-      comment: { type: Schema.Types.ObjectId, ref: "Comment" },
-      isChecked: { type: Boolean },
-    },
-  ],
+  feedComments: [{ type: Schema.Types.ObjectId, ref: "Comment" }],
 });
 
 exports.User = mongoose.model("User", userSchema);

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -149,10 +149,10 @@ router.delete("/:commentId", async (req, res, next) => {
     }
 
     for (const user of comment.publicUsers) {
-      user.receivedComments = await user.receivedComments.filter(
+      user.receivedComments = user.receivedComments.filter(
         (comment) => comment.toString() !== commentId,
       );
-      user.feedComments = await user.feedComments.filter(
+      user.feedComments = user.feedComments.filter(
         (comment) => comment.toString() !== commentId,
       );
 

--- a/src/routes/location.js
+++ b/src/routes/location.js
@@ -17,6 +17,17 @@ router.get("/", async function (req, res, next) {
 
     const pageComments = [];
 
+    for (const comment of allComments) {
+      if (comment.postUrl === pageUrl) {
+        if (
+          comment.allowPublic === true ||
+          comment.publicUsers.find(loginUser)
+        ) {
+          pageComments.push(comment);
+        }
+      }
+    }
+
     res.status(200).json({ pageComments });
   } catch (error) {
     return res.status(400).json({ message: "Failed to get comments." });

--- a/src/routes/location.js
+++ b/src/routes/location.js
@@ -1,0 +1,26 @@
+const express = require("express");
+
+const router = express.Router();
+
+const { User } = require("../models/User");
+const { Comment } = require("../models/Comment");
+
+router.get("/", async function (req, res, next) {
+  try {
+    const { pageUrl, userId } = req.query;
+    const allComments = await Comment.find().populate("creator");
+    const loginUser = await User.findById(userId);
+
+    if (!loginUser) {
+      return res.status(404).json({ message: "User not found." });
+    }
+
+    const pageComments = [];
+
+    res.status(200).json({ pageComments });
+  } catch (error) {
+    return res.status(400).json({ message: "Failed to get comments." });
+  }
+});
+
+module.exports = router;

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -9,7 +9,9 @@ router.post("/", async (req, res, next) => {
   try {
     const userData = req.body.user;
 
-    let user = await User.findOne({ email: userData.email });
+    let user = await User.findOne({ email: userData.email }).populate(
+      "friends",
+    );
 
     if (!user) {
       user = await User.create({

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -31,7 +31,9 @@ router.post("/client", verifyToken, async (req, res, next) => {
   try {
     const userData = req.user;
 
-    let user = await User.findOne({ email: userData.email });
+    let user = await User.findOne({ email: userData.email })
+      .populate("createdComments")
+      .populate("receivedComments");
 
     if (!user) {
       return res.status(404).json({ message: "User not found." });


### PR DESCRIPTION
### itsComments

## [location GET ](https://boom-plant-4c9.notion.site/BE-location-GET-d76b3971d3704b0f9a2fe25cd463b228?pvs=4)

## Todo

- [x]  웹페이지 이동시 `/location` GET요청
- [x]  req.query.pageUrl에 해당 url을 담아 전달
- [x]  req.query.userId에 해당 로그인유저 id 담아 전달
- [x]  전체 댓글중 postUrl이 req.query.pageUrl값과 같고 
          allowPublic값이 true거나
          allowPublic값이 false 이고 publickUsers 배열에 사용자 ID가 포함될경우 배열에 추가
- [x]  GET 요청에 대한 응답으로 댓글 배열 전달(실패시 결과와 에러메시지 전달)
- [x]  익스텐션 연동

## Description

- 응답으로 전달해줄 comments 배열 생성
- 전체 comments를 순회하면서 공개허용인 댓글 배열에 추가
- 전체 comments를 순회하면서 공개유저에 로그인 유저를 추가한 댓글을 배열에 추가
- 해당 배열 응답으로 전달

## Concern(필요시)

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
