### PR TITLE
[Feat]/friends router

### DIFF
--- a/src/loaders/routers.js
+++ b/src/loaders/routers.js
@@ -3,6 +3,7 @@ const loginRouter = require("../routes/login");
 const profileRouter = require("../routes/profile");
 const commentsRouter = require("../routes/comments");
 const locationRouter = require("../routes/location");
+const friendsRouter = require("../routes/friends");
 
 async function routerLoader(app) {
   app.use("/", indexRouter);
@@ -10,6 +11,7 @@ async function routerLoader(app) {
   app.use("/profile", profileRouter);
   app.use("/comments", commentsRouter);
   app.use("/location", locationRouter);
+  app.use("/friends", friendsRouter);
 }
 
 module.exports = routerLoader;

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -22,15 +22,25 @@ router.post(
         recipientEmail,
       } = req.body;
 
-      const screenshot = req.file.location;
-
-      const commentPosition = JSON.parse(postCoordinate);
-      const taggedUser = JSON.parse(publicUsers);
-
       const user = await User.findOne({ email: userData }).populate("friends");
 
       if (!user) {
         return res.status(404).json({ message: "User not found" });
+      }
+
+      const screenshot = req.file.location;
+      const commentPosition = JSON.parse(postCoordinate);
+      const taggedUser = JSON.parse(publicUsers);
+      const taggedUsersList = [];
+
+      if (taggedUser) {
+        for (const publicUser of taggedUser) {
+          const taggedFriends = user.friends.find(
+            (friend) => friend.nickname === publicUser,
+          );
+
+          taggedUsersList.push(taggedFriends._id);
+        }
       }
 
       if (text.length > 200) {
@@ -51,7 +61,7 @@ router.post(
         postCoordinate: commentPosition,
         screenshot,
         allowPublic,
-        publicUsers: taggedUser,
+        publicUsers: taggedUsersList,
         recipientEmail,
       });
 
@@ -62,7 +72,7 @@ router.post(
       if (newComment.publicUsers) {
         for (const publicUser of newComment.publicUsers) {
           const taggedFriends = user.friends.find(
-            (friend) => friend.nickname === publicUser,
+            (friend) => friend._id === publicUser,
           );
 
           taggedFriends.feedComments.push(newComment._id);

--- a/src/routes/friends.js
+++ b/src/routes/friends.js
@@ -38,4 +38,5 @@ router.patch("/addition", async function (req, res, next) {
 
   res.status(200).send({ friends });
 });
+
 module.exports = router;

--- a/src/routes/friends.js
+++ b/src/routes/friends.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const { User } = require("../models/User");
+
+const router = express.Router();
+
+router.get("/", async function (req, res, next) {
+  const userId = req.query.id;
+  const user = await User.findById(userId).populate("friends");
+
+  if (!user) {
+    return res.status(404).json({ message: "User not found." });
+  }
+
+  const friends = user.friends;
+
+  res.status(200).send({ friends });
+});
+
+module.exports = router;

--- a/src/routes/friends.js
+++ b/src/routes/friends.js
@@ -16,4 +16,18 @@ router.get("/", async function (req, res, next) {
   res.status(200).send({ friends });
 });
 
+router.patch("/addition", async function (req, res, next) {
+  const { userId, friendMail } = req.body;
+  const user = await User.findById(userId);
+  const friend = await User.findOne({ email: friendMail });
+
+  user.friends.push(friend);
+
+  await user.save();
+
+  const friends = user.friends;
+
+  res.status(200).send({ friends });
+});
+
 module.exports = router;

--- a/src/routes/friends.js
+++ b/src/routes/friends.js
@@ -19,7 +19,16 @@ router.get("/", async function (req, res, next) {
 router.patch("/addition", async function (req, res, next) {
   const { userId, friendMail } = req.body;
   const user = await User.findById(userId);
+
+  if (!user) {
+    return res.status(404).json({ message: "User not found." });
+  }
+
   const friend = await User.findOne({ email: friendMail });
+
+  if (!friend) {
+    return res.status(404).json({ message: "friend not found." });
+  }
 
   user.friends.push(friend);
 
@@ -29,5 +38,4 @@ router.patch("/addition", async function (req, res, next) {
 
   res.status(200).send({ friends });
 });
-
 module.exports = router;

--- a/src/routes/location.js
+++ b/src/routes/location.js
@@ -33,7 +33,6 @@ router.get("/", async function (req, res, next) {
 
     res.status(200).json({ pageComments });
   } catch (error) {
-    console.log(error);
     return res.status(400).json({ message: "Failed to get comments." });
   }
 });

--- a/src/routes/location.js
+++ b/src/routes/location.js
@@ -21,7 +21,10 @@ router.get("/", async function (req, res, next) {
       if (comment.postUrl === pageUrl) {
         if (
           comment.allowPublic === true ||
-          comment.publicUsers.find(loginUser)
+          comment.creator.email === loginUser.email ||
+          comment.publicUsers.find(
+            (user) => user.toString() === loginUser._id.toString(),
+          )
         ) {
           pageComments.push(comment);
         }
@@ -30,6 +33,7 @@ router.get("/", async function (req, res, next) {
 
     res.status(200).json({ pageComments });
   } catch (error) {
+    console.log(error);
     return res.status(400).json({ message: "Failed to get comments." });
   }
 });


### PR DESCRIPTION
### itsComments

## [[BE]friends/addition PATCH](https://boom-plant-4c9.notion.site/BE-friends-addition-PATCH-a98de5d776f949d8a638cbff117b70b7?pvs=4)

## Todo

- [x]  친구 추가시 `/friends/addition/` PATCH 요청
- [x]  전달받은 사용자 id를 통해서 사용자 데이터를 찾는다.
- [x]  전체 user에서 PATCH로 전달받은 email을 가진 user를 찾는다(친구계정)
- [x]  사용자 user의 friend 배열에 친구 계정_id를 push
- [x]  응답으로 친구배열 전달(실패시 결과와 에러메시지 전달)
- [x]  에러 핸들링

## Description

- location 비공개 댓글 보여주는 권한 관련 로직 수정
   - 댓글 작성유저이거나 태그된 유저에 대해서 허용
- friends 라우터 생성
- /frinds 로 get요청시 req.query.id로 받은 userId로 해당 user를 조회
- 해당 user의 friends속성을 응답으로 전달
- 해당 user가 없을시 에러메시지 반환
- /friends/addition 로 patch 요청시 바디에 담긴 userId로 해당 user 조회
- 해당 user가 없을시 에러메시지 반환
- 바디에 담긴 email로 user 조회
- 해당 user(친구)가 없을시 에러메시지 반환
- 해당 user 조회시 해당 유저 로그인 유저의 friends배열에 추가하고 유저의 friends속성을 응답으로 전달

## Concern(필요시)

- friend 목록의 경우 초기에 로그인 당시에 populate하지 않고 로그인 컴포넌트에 들어왔을때 요청하고 응답으로 friends속성을 배열로 받습니다.

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
