### PR TITLE
[Feat] Comment recomment

### DIFF
--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -125,8 +125,7 @@ router.get("/:commentId", async (req, res, next) => {
 
 router.patch("/recomments", async (req, res, next) => {
   try {
-    const { userData, userId, commentId, replyId, postDate, text, action } =
-      req.body;
+    const { userId, commentId, replyId, postDate, text, action } = req.body;
 
     if (action === "delete") {
       const comment = await Comment.findById(commentId);
@@ -178,7 +177,7 @@ router.patch("/recomments", async (req, res, next) => {
         res.status(200).json({ message: "Recomment is successfully deleted." });
       }
     } else if (action === "update") {
-      const user = await User.findOne({ email: userData.email });
+      const user = await User.findById(userId);
 
       if (!user) {
         return res.status(404).json({ message: "User not found" });

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -123,6 +123,46 @@ router.get("/:commentId", async (req, res, next) => {
   }
 });
 
+router.post("/recomments", async (req, res, next) => {
+  try {
+    const { userData, text, postDate, commentId } = req.body;
+
+    const user = await User.findOne({ email: userData.email });
+
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const comment = await Comment.findById(commentId);
+
+    if (!comment) {
+      return res.status(404).json({ message: "Comment not found" });
+    }
+
+    const reComment = {
+      text,
+      creator: user._id,
+      postDate,
+    };
+
+    comment.reComments.push(reComment);
+    await comment.save();
+
+    user.repliedComments.push({
+      comment: comment._id,
+      text,
+    });
+
+    await user.save();
+
+    res
+      .status(200)
+      .json({ message: "Recomment created successfully", reComment });
+  } catch (error) {
+    return res.status(400).json({ message: "Recomment creation failed." });
+  }
+});
+
 router.delete("/:commentId", async (req, res, next) => {
   try {
     const commentId = req.params.commentId;

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -92,32 +92,20 @@ router.post(
 router.get("/:commentId", async (req, res, next) => {
   try {
     const commentId = req.params.commentId;
-    const comment = await Comment.findById(commentId);
+    const comment = await Comment.findById(commentId)
+      .populate("creator")
+      .populate({ path: "reComments", populate: { path: "creator" } });
 
     if (!comment) {
       return res.status(404).json({ error: "Failed to get comments." });
     }
-
-    const userId = req.query.userId;
-
-    if (comment.allowPublic === false) {
-      if (!userId && !comment.publicUsers.find(userId)) {
-        return res.status(401).json({ error: "You do not have access." });
-      }
-    }
-
-    const user = await User.findById(userId);
-    user.feedComments = user.feedComments.filter(
-      (comment) => comment._id.toString() !== commentId,
-    );
-
-    await user.save();
 
     res.status(200).json({
       comments: {
         commentId: comment._id,
         text: comment.text,
         creator: comment.creator,
+        postDate: comment.postDate,
         postUrl: comment.postUrl,
         postCoordinate: {
           x: comment.postCoordinate.x,

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -200,7 +200,7 @@ router.delete("/recomments/:commentId/:replyId", async (req, res, next) => {
       await comment.save();
 
       const writer = await User.findById(recomment.creator);
-      console.log(writer);
+
       if (!writer) {
         return res
           .status(404)


### PR DESCRIPTION
### itsComments

## [[BE]comments/recomments PATCH](https://boom-plant-4c9.notion.site/BE-comments-recomments-PATCH-fc1f365c810a4160980ddbc49513a3c3?pvs=74)

## Todo

- [x] 해당 댓글 페이지에서 대댓글 작성시 /comments/recomments  요청
- [x] 해당 comment에 reComments 생성
- [x] 응답으로 결과 전달(실패시 결과와 에러메시지 전달)

## Description

- 작업 내용
1. 답글 삭제 엔드포인트:
답글 삭제를 위한 새로운 라우트 추가 (DELETE /recomments/:commentId/:replyId).
사용자 권한을 확인하여 답글 삭제를 허용하기 전에 로직 구현.
코멘트의 reComments 배열에서 지정된 답글 제거.
답글 생성자의 repliedComments 배열 업데이트.

2. 코멘트 검색 엔드포인트:
GET /:commentId 엔드포인트 업데이트하여 보다 포괄적인 코멘트 정보 제공.
주 코멘트와 답글 내의 creator 필드를 팝업.
추가 정보로는 게시 날짜, 게시 URL, 게시 좌표, 스크린샷, 공개 설정, 공개 사용자 및 수신자 이메일이 포함.

3. 답글 생성 엔드포인트:
답글 게시를 위한 새로운 엔드포인트 구현 (POST /recomments).
사용자 데이터, 답글 텍스트, 게시 날짜 및 관련된 코멘트 ID를 유효성 검사하고 처리.
생성된 답글을 코멘트의 reComments 배열에 추가.
사용자의 repliedComments 배열을 새로운 답글에 대한 정보로 업데이트.

## Concern(필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
