### PR TITLE
Feat/comments delete

### DIFF
--- a/src/models/Comment.js
+++ b/src/models/Comment.js
@@ -4,7 +4,7 @@ const { Schema } = mongoose;
 
 const reCommentSchema = new mongoose.Schema({
   text: { type: String, required: true },
-  creator: [{ type: Schema.Types.ObjectId, ref: "User", required: true }],
+  creator: { type: Schema.Types.ObjectId, ref: "User", required: true },
   postDate: { type: Date, required: true },
 });
 

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -266,6 +266,7 @@ router.delete("/:commentId", async (req, res, next) => {
 
     for (const reComment of comment.reComments) {
       const writer = await User.findById(reComment.creator);
+
       writer.repliedComments = writer.repliedComments?.filter(
         (reply) => reply.comment.toString() !== commentId,
       );
@@ -275,9 +276,11 @@ router.delete("/:commentId", async (req, res, next) => {
 
     for (const userId of comment.publicUsers) {
       const user = await User.findById(userId);
+
       user.receivedComments = user.receivedComments?.filter(
         (comment) => comment.toString() !== commentId,
       );
+
       user.feedComments = user.feedComments?.filter(
         (comment) => comment.toString() !== commentId,
       );


### PR DESCRIPTION
### itsComments

## [[BE]comments/:commentId DELETE](https://boom-plant-4c9.notion.site/BE-comments-commentId-DELETE-107b1802358d498a8d4de2e9f6223ccf?pvs=4)

## Todo

- [x]  자신이 작성한 commetn의 경우 삭제버튼이 활성화 되어있고 클릭시 `/comment/commintId` DELETE요청
- [x]  commentId가 일치하는 댓글 삭제
- [x]  해당 사용자의 createdComments 요소 배열에서 해당 comment 삭제
- [x]  전체 사용자의 particpatedComments 요소 배열에서 해당 comment 존재시 삭제
- [x]  응답으로 결과 전달(실패시 결과와 에러메시지 전달)

## Description

- req.params로 전달받은 commentId와 일치하는 comment가 없을시 404에러 메시지 전달
- 해당 comment의 creator와 동일한 user._Id가 없을시 404에러 메시지 전달
- req.body로 전달받은 userId와 해당 comment의 creator가 다를경우 404 에러 메시지 전달
- 해당 user의 createdComments 배열에서 해당 comment를 제외
- comment의 reComments를 돌면서 해당 reComments의 작성자 접근
- reComments작성자의 repliedComments 배열에서 해당 comment를 제외
- comment의 publicUsers를 돌면서 해당 user들에 접근
- 해당 user의 receivedComments, feedComments 배열에서 해당 comment를 제외
- 해당 comment 삭제


## Concern(필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
