### PR TITLE
[Feat] Add logic to remove viewed comments from the user.feedComments

### DIFF
--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -112,6 +112,7 @@ router.post(
 router.get("/:commentId", async (req, res, next) => {
   try {
     const commentId = req.params.commentId;
+    const userId = req.query.userId;
     const comment = await Comment.findById(commentId)
       .populate("creator")
       .populate({ path: "reComments", populate: { path: "creator" } });
@@ -119,6 +120,18 @@ router.get("/:commentId", async (req, res, next) => {
     if (!comment) {
       return res.status(404).json({ error: "Failed to get comments." });
     }
+
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    user.feedComments = user.feedComments.filter(
+      (comment) => comment.toString() !== commentId,
+    );
+
+    await user.save();
 
     res.status(200).json({
       comments: {


### PR DESCRIPTION
### itsComments

## 커멘트페이지 접근시 사용자의 피드배열에서 해당 커멘트 삭제 로직 구현

## Todo

- [x] 로그인 유저의 피드컴포넌트에 해당 댓글이 있을시 삭제

## Description

- req.query.userId로 로그인 user 데이터 조회
- user가 없을경우 반환
- user의 feedComments에서 req.params로 전달받은 commentId와 동일한 아이디를 갖는 comment가 있는지 확인
- 있을경우 제외

## Concern(필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
