### PR TITLE
[Refactor] Implement automatic deletion logic using MongoDB TTL

### DIFF
--- a/src/models/Comment.js
+++ b/src/models/Comment.js
@@ -22,6 +22,15 @@ const commentSchema = new mongoose.Schema({
   publicUsers: [{ type: Schema.Types.ObjectId, ref: "User" }],
   recipientEmail: [{ type: String }],
   reComments: [reCommentSchema],
+  expiresAt: { type: Date, index: true },
+});
+
+commentSchema.pre("save", async function (next) {
+  if (this.creator.toString() === process.env.NON_MEMBER) {
+    this.expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+  }
+
+  next();
 });
 
 exports.Comment = mongoose.model("Comment", commentSchema);

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -108,15 +108,6 @@ router.post(
 
       user.createdComments.push(newComment._id);
 
-      if (user._id.toString() === process.env.NON_MEMBER) {
-        setTimeout(
-          async () => {
-            await Comment.deleteOne({ _id: newComment._id });
-          },
-          60 * 60 * 1000,
-        );
-      }
-
       await user.save();
 
       if (newComment.publicUsers) {


### PR DESCRIPTION
### itsComments

## 비회원 댓글 자동 삭제 로직 변경

## Todo

- [x] 칸반 외 작업

## Description

- 비회원 댓글 삭제 몽고DB TTL 적용
- 커맨트 스키마에  TTL 설정 필드 expiresAt 추가
- pre 미들웨어를 사용하여 save가 발생할경우 발생 이벤트추가
- 댓글작성자가 비회원일경우 TTL 인덱스를 활용하여 해당 문서가 1시간 후에 자동으로 삭제 로직 추가

## Concern(필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
