### PR TITLE
[Feat] Implement self-friend restriction feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 .husky
 
 config
+.elasticbeanstalk

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "eslint-config": "^0.3.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "husky": "^9.0.7",
         "lint-staged": "^15.2.1",
         "prettier": "3.2.4"
       }
@@ -5050,21 +5049,6 @@
       "dev": true,
       "engines": {
         "node": ">=16.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
-      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==",
-      "dev": true,
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
         "eslint-plugin-prettier": "^5.1.3",
         "lint-staged": "^15.2.1",
         "prettier": "3.2.4"
+      },
+      "engines": {
+        "node": "18.16.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "itscomments-back",
   "version": "1.0.0",
+  "engines": {
+    "node": "18.16.0"
+  },
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint-config": "^0.3.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "husky": "^9.0.7",
     "lint-staged": "^15.2.1",
     "prettier": "3.2.4"
   },

--- a/src/routes/friends.js
+++ b/src/routes/friends.js
@@ -38,6 +38,12 @@ router.patch("/addition", async function (req, res, next) {
     return res.status(400).json({ message: "Friend already exists." });
   }
 
+  if (user.mail === friendMail) {
+    return res
+      .status(400)
+      .json({ message: "You can't add yourself as a friend." });
+  }
+
   user.friends.push(friend);
 
   await user.save();


### PR DESCRIPTION
### itsComments

## 자기자신 친구추가 기능 제거

## Todo

- [x] 칸반 외 작업

## Description

- 기존 테스트를 위해 허용했던 자기자신을 친구추가하는 기능 제한
- 조회환 user의 mail값과 요청의 body로 받은 frinedMail값을 비교
- 위의 두값이 동일할 경우 You can't add yourself as a friend. 메시지 응답

## Concern(필요시)

- Elastic Beanstalk 배포중 허스키 명령어 오류로 인해 임시 삭제하였습니다.

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
